### PR TITLE
Add Replicate demo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ControlNet
 
+[![Try a demo on Replicate](https://replicate.com/jagilley/controlnet-seg/badge)](https://replicate.com/jagilley/controlnet-seg)
+
 Cog implementation of [Adding Conditional Control to Text-to-Image Diffusion Models](https://github.com/lllyasviel/ControlNet/raw/main/github_page/control.pdf).
 
 To run this Cog model:


### PR DESCRIPTION
This PR adds a badge with a link to your model on Replicate, making it easier for users to try it out. 

Feel free to close if you don't want this, but many model creators have found it helpful.